### PR TITLE
Fix crash issue with entity index 0 (worldspawn?)

### DIFF
--- a/store/modules/hats.sp
+++ b/store/modules/hats.sp
@@ -177,7 +177,7 @@ void Store_RemoveClientHats(int client, int slot)
     if(g_iClientHats[client][slot] != INVALID_ENT_REFERENCE)
     {
         int entity = EntRefToEntIndex(g_iClientHats[client][slot]);
-        if(IsValidEdict(entity))
+        if(entity > 0 && IsValidEdict(entity))
         {
             SDKUnhook(entity, SDKHook_SetTransmit, Hook_SetTransmit_Hat);
             AcceptEntityInput(entity, "Kill");

--- a/store/modules/trail.sp
+++ b/store/modules/trail.sp
@@ -62,7 +62,7 @@ void Store_RemoveClientTrail(int client, int slot)
     if(g_iClientTrails[client][slot] != INVALID_ENT_REFERENCE)
     {
         int entity = EntRefToEntIndex(g_iClientTrails[client][slot]);
-        if(IsValidEdict(entity))
+        if(entity > 0 && IsValidEdict(entity))
         {
 #if defined AllowHide
             SDKUnhook(entity, SDKHook_SetTransmit, Hook_SetTransmit_Trail);


### PR DESCRIPTION
This will fix a crash issue with trail and hats module. Maybe we could check the entity classname for "prop_dynamic_override" (hats) and "env_spritetrail" (trail), should be more save.