### PR TITLE
IsPluginRunning should return true...

### DIFF
--- a/store.sp
+++ b/store.sp
@@ -3793,7 +3793,25 @@ bool IsPluginRunning(Handle plugin, const char[] file)
     Handle dummy = FindPluginByFile(file);
 
     if(dummy == INVALID_HANDLE || dummy != plugin)
+    {
+        if (StrEqual(file, "store.smx", false) || 
+            StrEqual(file, "store_bh.smx", false) ||
+            StrEqual(file, "store_hg.smx", false) ||
+            StrEqual(file, "store_hz.smx", false) ||
+            StrEqual(file, "store_jb.smx", false) ||
+            StrEqual(file, "store_kz.smx", false) ||
+            StrEqual(file, "store_mg.smx", false) ||
+            StrEqual(file, "store_pr.smx", false) ||
+            StrEqual(file, "store_sr.smx", false) ||
+            StrEqual(file, "store_tt.smx", false) ||
+            StrEqual(file, "store_ze.smx", false)
+            )
+        {
+            return true;
+        }
+        
         return false;
+    }
 
     return (GetPluginStatus(plugin) == Plugin_Running);
 }

--- a/store.sp
+++ b/store.sp
@@ -3794,18 +3794,7 @@ bool IsPluginRunning(Handle plugin, const char[] file)
 
     if(dummy == INVALID_HANDLE || dummy != plugin)
     {
-        if (StrEqual(file, "store.smx", false) || 
-            StrEqual(file, "store_bh.smx", false) ||
-            StrEqual(file, "store_hg.smx", false) ||
-            StrEqual(file, "store_hz.smx", false) ||
-            StrEqual(file, "store_jb.smx", false) ||
-            StrEqual(file, "store_kz.smx", false) ||
-            StrEqual(file, "store_mg.smx", false) ||
-            StrEqual(file, "store_pr.smx", false) ||
-            StrEqual(file, "store_sr.smx", false) ||
-            StrEqual(file, "store_tt.smx", false) ||
-            StrEqual(file, "store_ze.smx", false)
-            )
+        if (StrContains(file, "store.smx", false) != -1)
         {
             return true;
         }


### PR DESCRIPTION
if char file is the plugin itself. I run into this issue https://pastebin.com/RtwskcW1 that all plugins has the correct handle, but store.smx itself has 0 as handle.

This check is probably bad (because build package has multiple smx files), but should avoid this issue (for me).